### PR TITLE
CC-12637: Support configurable products in the wish list.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "spryker/price-product": "^1.0.0 || ^2.0.0 || ^4.0.0",
     "spryker/product": "^5.0.0 || ^6.0.0",
     "spryker/propel-orm": "^1.1.0",
-    "spryker/wishlist-extension": "^1.0.0",
+    "spryker/wishlist-extension": "^1.3.0",
     "spryker/zed-request": "^3.0.0"
   },
   "require-dev": {

--- a/src/Spryker/Client/Wishlist/WishlistClient.php
+++ b/src/Spryker/Client/Wishlist/WishlistClient.php
@@ -11,6 +11,7 @@ use Generated\Shared\Transfer\CustomerTransfer;
 use Generated\Shared\Transfer\WishlistCollectionTransfer;
 use Generated\Shared\Transfer\WishlistFilterTransfer;
 use Generated\Shared\Transfer\WishlistItemCollectionTransfer;
+use Generated\Shared\Transfer\WishlistItemResponseTransfer;
 use Generated\Shared\Transfer\WishlistItemTransfer;
 use Generated\Shared\Transfer\WishlistMoveToCartRequestCollectionTransfer;
 use Generated\Shared\Transfer\WishlistOverviewRequestTransfer;
@@ -270,5 +271,19 @@ class WishlistClient extends AbstractClient implements WishlistClientInterface
     public function getWishlistByFilter(WishlistFilterTransfer $wishlistFilterTransfer): WishlistResponseTransfer
     {
         return $this->getZedStub()->getWishlistByFilter($wishlistFilterTransfer);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @api
+     *
+     * @param \Generated\Shared\Transfer\WishlistItemTransfer $wishlistItemTransfer
+     *
+     * @return \Generated\Shared\Transfer\WishlistItemResponseTransfer
+     */
+    public function updateWishlistItem(WishlistItemTransfer $wishlistItemTransfer): WishlistItemResponseTransfer
+    {
+        return $this->getZedStub()->updateWishlistItem($wishlistItemTransfer);
     }
 }

--- a/src/Spryker/Client/Wishlist/WishlistClientInterface.php
+++ b/src/Spryker/Client/Wishlist/WishlistClientInterface.php
@@ -182,7 +182,9 @@ interface WishlistClientInterface
     /**
      * Specification:
      * - Makes Zed request.
-     * - Expects `WishlistItemTransfer.idWishlistItem` or `WishlistItemTransfer.uuid` to be set.
+     * - Expects `WishlistItemTransfer.idWishlistItem` to be set.
+     * - Expects `WishlistItemTransfer.sku` to be set.
+     * - Executes `AddItemPreCheckPluginInterface` plugin stack.
      * - Retrieves wishlist item by data provided in the `WishlistItemTransfer` from Persistence.
      * - Updates existing wishlist item in database.
      * - Returns `isSuccess=true` with updated wishlist item on success or `isSuccess=false` with error messages otherwise.

--- a/src/Spryker/Client/Wishlist/WishlistClientInterface.php
+++ b/src/Spryker/Client/Wishlist/WishlistClientInterface.php
@@ -11,6 +11,7 @@ use Generated\Shared\Transfer\CustomerTransfer;
 use Generated\Shared\Transfer\WishlistCollectionTransfer;
 use Generated\Shared\Transfer\WishlistFilterTransfer;
 use Generated\Shared\Transfer\WishlistItemCollectionTransfer;
+use Generated\Shared\Transfer\WishlistItemResponseTransfer;
 use Generated\Shared\Transfer\WishlistItemTransfer;
 use Generated\Shared\Transfer\WishlistMoveToCartRequestCollectionTransfer;
 use Generated\Shared\Transfer\WishlistOverviewRequestTransfer;
@@ -177,4 +178,20 @@ interface WishlistClientInterface
      * @return \Generated\Shared\Transfer\WishlistResponseTransfer
      */
     public function getWishlistByFilter(WishlistFilterTransfer $wishlistFilterTransfer): WishlistResponseTransfer;
+
+    /**
+     * Specification:
+     * - Makes Zed request.
+     * - Expects `WishlistItemTransfer.idWishlistItem` or `WishlistItemTransfer.uuid` to be set.
+     * - Retrieves wishlist item by data provided in the `WishlistItemTransfer` from Persistence.
+     * - Updates existing wishlist item in database.
+     * - Returns `isSuccess=true` with updated wishlist item on success or `isSuccess=false` with error messages otherwise.
+     *
+     * @api
+     *
+     * @param \Generated\Shared\Transfer\WishlistItemTransfer $wishlistItemTransfer
+     *
+     * @return \Generated\Shared\Transfer\WishlistItemResponseTransfer
+     */
+    public function updateWishlistItem(WishlistItemTransfer $wishlistItemTransfer): WishlistItemResponseTransfer;
 }

--- a/src/Spryker/Client/Wishlist/WishlistClientInterface.php
+++ b/src/Spryker/Client/Wishlist/WishlistClientInterface.php
@@ -184,8 +184,9 @@ interface WishlistClientInterface
      * - Makes Zed request.
      * - Expects `WishlistItemTransfer.idWishlistItem` to be set.
      * - Expects `WishlistItemTransfer.sku` to be set.
-     * - Executes `AddItemPreCheckPluginInterface` plugin stack.
+     * - Executes `UpdateItemPreCheckPluginInterface` plugin stack.
      * - Retrieves wishlist item by data provided in the `WishlistItemTransfer` from Persistence.
+     * - Executes `WishlistPreUpdateItemPluginInterface` plugin stack.
      * - Updates existing wishlist item in database.
      * - Returns `isSuccess=true` with updated wishlist item on success or `isSuccess=false` with error messages otherwise.
      *

--- a/src/Spryker/Client/Wishlist/Zed/WishlistStub.php
+++ b/src/Spryker/Client/Wishlist/Zed/WishlistStub.php
@@ -10,6 +10,7 @@ namespace Spryker\Client\Wishlist\Zed;
 use Generated\Shared\Transfer\CustomerTransfer;
 use Generated\Shared\Transfer\WishlistFilterTransfer;
 use Generated\Shared\Transfer\WishlistItemCollectionTransfer;
+use Generated\Shared\Transfer\WishlistItemResponseTransfer;
 use Generated\Shared\Transfer\WishlistItemTransfer;
 use Generated\Shared\Transfer\WishlistOverviewRequestTransfer;
 use Generated\Shared\Transfer\WishlistResponseTransfer;
@@ -200,5 +201,20 @@ class WishlistStub implements WishlistStubInterface
         $wishlistResponseTransfer = $this->zedStub->call('/wishlist/gateway/get-wishlist-by-filter', $wishlistFilterTransfer);
 
         return $wishlistResponseTransfer;
+    }
+
+    /**
+     * @uses \Spryker\Zed\Wishlist\Communication\Controller\GatewayController::updateWishlistItemAction()
+     *
+     * @param \Generated\Shared\Transfer\WishlistItemTransfer $wishlistItemTransfer
+     *
+     * @return \Generated\Shared\Transfer\WishlistItemResponseTransfer
+     */
+    public function updateWishlistItem(WishlistItemTransfer $wishlistItemTransfer): WishlistItemResponseTransfer
+    {
+        /** @var \Generated\Shared\Transfer\WishlistItemResponseTransfer $wishlistItemResponseTransfer */
+        $wishlistItemResponseTransfer = $this->zedStub->call('/wishlist/gateway/update-wishlist-item', $wishlistItemTransfer);
+
+        return $wishlistItemResponseTransfer;
     }
 }

--- a/src/Spryker/Client/Wishlist/Zed/WishlistStubInterface.php
+++ b/src/Spryker/Client/Wishlist/Zed/WishlistStubInterface.php
@@ -10,6 +10,7 @@ namespace Spryker\Client\Wishlist\Zed;
 use Generated\Shared\Transfer\CustomerTransfer;
 use Generated\Shared\Transfer\WishlistFilterTransfer;
 use Generated\Shared\Transfer\WishlistItemCollectionTransfer;
+use Generated\Shared\Transfer\WishlistItemResponseTransfer;
 use Generated\Shared\Transfer\WishlistItemTransfer;
 use Generated\Shared\Transfer\WishlistOverviewRequestTransfer;
 use Generated\Shared\Transfer\WishlistResponseTransfer;
@@ -107,4 +108,11 @@ interface WishlistStubInterface
      * @return \Generated\Shared\Transfer\WishlistResponseTransfer
      */
     public function getWishlistByFilter(WishlistFilterTransfer $wishlistFilterTransfer): WishlistResponseTransfer;
+
+    /**
+     * @param \Generated\Shared\Transfer\WishlistItemTransfer $wishlistItemTransfer
+     *
+     * @return \Generated\Shared\Transfer\WishlistItemResponseTransfer
+     */
+    public function updateWishlistItem(WishlistItemTransfer $wishlistItemTransfer): WishlistItemResponseTransfer;
 }

--- a/src/Spryker/Shared/Wishlist/Transfer/wishlist.transfer.xml
+++ b/src/Spryker/Shared/Wishlist/Transfer/wishlist.transfer.xml
@@ -113,4 +113,14 @@
         <property name="isSuccess" type="bool"/>
     </transfer>
 
+    <transfer name="Message">
+        <property name="value" type="string"/>
+    </transfer>
+
+    <transfer name="WishlistItemResponse">
+        <property name="wishlistItem" type="WishlistItem"/>
+        <property name="isSuccess" type="bool"/>
+        <property name="messages" type="Message[]" singular="message"/>
+    </transfer>
+
 </transfers>

--- a/src/Spryker/Shared/Wishlist/Transfer/wishlist.transfer.xml
+++ b/src/Spryker/Shared/Wishlist/Transfer/wishlist.transfer.xml
@@ -113,6 +113,10 @@
         <property name="isSuccess" type="bool"/>
     </transfer>
 
+    <transfer name="WishlistPreUpdateItemCheckResponse">
+        <property name="isSuccess" type="bool"/>
+    </transfer>
+
     <transfer name="Message">
         <property name="value" type="string"/>
     </transfer>

--- a/src/Spryker/Zed/Wishlist/Business/Updater/WishlistItemUpdaterInterface.php
+++ b/src/Spryker/Zed/Wishlist/Business/Updater/WishlistItemUpdaterInterface.php
@@ -5,12 +5,12 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
-namespace Spryker\Zed\Wishlist\Business\Writer;
+namespace Spryker\Zed\Wishlist\Business\Updater;
 
 use Generated\Shared\Transfer\WishlistItemResponseTransfer;
 use Generated\Shared\Transfer\WishlistItemTransfer;
 
-interface WishlistItemWriterInterface
+interface WishlistItemUpdaterInterface
 {
     /**
      * @param \Generated\Shared\Transfer\WishlistItemTransfer $wishlistItemTransfer

--- a/src/Spryker/Zed/Wishlist/Business/WishlistBusinessFactory.php
+++ b/src/Spryker/Zed/Wishlist/Business/WishlistBusinessFactory.php
@@ -11,12 +11,15 @@ use Spryker\Zed\Kernel\Business\AbstractBusinessFactory;
 use Spryker\Zed\Wishlist\Business\Model\Reader;
 use Spryker\Zed\Wishlist\Business\Model\Writer;
 use Spryker\Zed\Wishlist\Business\Transfer\WishlistTransferMapper;
+use Spryker\Zed\Wishlist\Business\Writer\WishlistItemWriter;
+use Spryker\Zed\Wishlist\Business\Writer\WishlistItemWriterInterface;
 use Spryker\Zed\Wishlist\WishlistDependencyProvider;
 
 /**
  * @method \Spryker\Zed\Wishlist\Persistence\WishlistQueryContainerInterface getQueryContainer()
  * @method \Spryker\Zed\Wishlist\WishlistConfig getConfig()
  * @method \Spryker\Zed\Wishlist\Persistence\WishlistRepositoryInterface getRepository()
+ * @method \Spryker\Zed\Wishlist\Persistence\WishlistEntityManagerInterface getEntityManager()
  */
 class WishlistBusinessFactory extends AbstractBusinessFactory
 {
@@ -53,6 +56,17 @@ class WishlistBusinessFactory extends AbstractBusinessFactory
     {
         return new WishlistTransferMapper(
             $this->getItemExpanderPlugins()
+        );
+    }
+
+    /**
+     * @return \Spryker\Zed\Wishlist\Business\Writer\WishlistItemWriterInterface
+     */
+    public function createWishlistItemWriter(): WishlistItemWriterInterface
+    {
+        return new WishlistItemWriter(
+            $this->getEntityManager(),
+            $this->getRepository()
         );
     }
 

--- a/src/Spryker/Zed/Wishlist/Business/WishlistBusinessFactory.php
+++ b/src/Spryker/Zed/Wishlist/Business/WishlistBusinessFactory.php
@@ -68,7 +68,8 @@ class WishlistBusinessFactory extends AbstractBusinessFactory
             $this->getEntityManager(),
             $this->getRepository(),
             $this->getProductFacade(),
-            $this->getAddItemPreCheckPlugins()
+            $this->getUpdateItemPreCheckPlugins(),
+            $this->getWishlistPreUpdateItemPlugins()
         );
     }
 
@@ -102,5 +103,21 @@ class WishlistBusinessFactory extends AbstractBusinessFactory
     public function getAddItemPreCheckPlugins(): array
     {
         return $this->getProvidedDependency(WishlistDependencyProvider::PLUGINS_ADD_ITEM_PRE_CHECK);
+    }
+
+    /**
+     * @return array<\Spryker\Zed\WishlistExtension\Dependency\Plugin\UpdateItemPreCheckPluginInterface>
+     */
+    public function getUpdateItemPreCheckPlugins(): array
+    {
+        return $this->getProvidedDependency(WishlistDependencyProvider::PLUGINS_UPDATE_ITEM_PRE_CHECK);
+    }
+
+    /**
+     * @return array<\Spryker\Zed\WishlistExtension\Dependency\Plugin\WishlistPreUpdateItemPluginInterface>
+     */
+    public function getWishlistPreUpdateItemPlugins(): array
+    {
+        return $this->getProvidedDependency(WishlistDependencyProvider::PLUGINS_WISHLIST_PRE_UPDATE_ITEM);
     }
 }

--- a/src/Spryker/Zed/Wishlist/Business/WishlistBusinessFactory.php
+++ b/src/Spryker/Zed/Wishlist/Business/WishlistBusinessFactory.php
@@ -11,8 +11,8 @@ use Spryker\Zed\Kernel\Business\AbstractBusinessFactory;
 use Spryker\Zed\Wishlist\Business\Model\Reader;
 use Spryker\Zed\Wishlist\Business\Model\Writer;
 use Spryker\Zed\Wishlist\Business\Transfer\WishlistTransferMapper;
-use Spryker\Zed\Wishlist\Business\Writer\WishlistItemWriter;
-use Spryker\Zed\Wishlist\Business\Writer\WishlistItemWriterInterface;
+use Spryker\Zed\Wishlist\Business\Updater\WishlistItemUpdater;
+use Spryker\Zed\Wishlist\Business\Updater\WishlistItemUpdaterInterface;
 use Spryker\Zed\Wishlist\WishlistDependencyProvider;
 
 /**
@@ -60,13 +60,15 @@ class WishlistBusinessFactory extends AbstractBusinessFactory
     }
 
     /**
-     * @return \Spryker\Zed\Wishlist\Business\Writer\WishlistItemWriterInterface
+     * @return \Spryker\Zed\Wishlist\Business\Updater\WishlistItemUpdaterInterface
      */
-    public function createWishlistItemWriter(): WishlistItemWriterInterface
+    public function createWishlistItemUpdater(): WishlistItemUpdaterInterface
     {
-        return new WishlistItemWriter(
+        return new WishlistItemUpdater(
             $this->getEntityManager(),
-            $this->getRepository()
+            $this->getRepository(),
+            $this->getProductFacade(),
+            $this->getAddItemPreCheckPlugins()
         );
     }
 

--- a/src/Spryker/Zed/Wishlist/Business/WishlistFacade.php
+++ b/src/Spryker/Zed/Wishlist/Business/WishlistFacade.php
@@ -276,7 +276,7 @@ class WishlistFacade extends AbstractFacade implements WishlistFacadeInterface
     public function updateWishlistItem(WishlistItemTransfer $wishlistItemTransfer): WishlistItemResponseTransfer
     {
         return $this->getFactory()
-            ->createWishlistItemWriter()
+            ->createWishlistItemUpdater()
             ->updateWishlistItem($wishlistItemTransfer);
     }
 }

--- a/src/Spryker/Zed/Wishlist/Business/WishlistFacade.php
+++ b/src/Spryker/Zed/Wishlist/Business/WishlistFacade.php
@@ -10,6 +10,7 @@ namespace Spryker\Zed\Wishlist\Business;
 use Generated\Shared\Transfer\CustomerTransfer;
 use Generated\Shared\Transfer\WishlistFilterTransfer;
 use Generated\Shared\Transfer\WishlistItemCollectionTransfer;
+use Generated\Shared\Transfer\WishlistItemResponseTransfer;
 use Generated\Shared\Transfer\WishlistItemTransfer;
 use Generated\Shared\Transfer\WishlistOverviewRequestTransfer;
 use Generated\Shared\Transfer\WishlistResponseTransfer;
@@ -261,5 +262,21 @@ class WishlistFacade extends AbstractFacade implements WishlistFacadeInterface
         return $this->getFactory()
             ->createReader()
             ->getWishlistByFilter($wishlistFilterTransfer);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @api
+     *
+     * @param \Generated\Shared\Transfer\WishlistItemTransfer $wishlistItemTransfer
+     *
+     * @return \Generated\Shared\Transfer\WishlistItemResponseTransfer
+     */
+    public function updateWishlistItem(WishlistItemTransfer $wishlistItemTransfer): WishlistItemResponseTransfer
+    {
+        return $this->getFactory()
+            ->createWishlistItemWriter()
+            ->updateWishlistItem($wishlistItemTransfer);
     }
 }

--- a/src/Spryker/Zed/Wishlist/Business/WishlistFacadeInterface.php
+++ b/src/Spryker/Zed/Wishlist/Business/WishlistFacadeInterface.php
@@ -239,7 +239,9 @@ interface WishlistFacadeInterface
 
     /**
      * Specification:
-     * - Expects `WishlistItemTransfer.idWishlistItem` or `WishlistItemTransfer.uuid` to be set.
+     * - Expects `WishlistItemTransfer.idWishlistItem` to be set.
+     * - Expects `WishlistItemTransfer.sku` to be set.
+     * - Executes `AddItemPreCheckPluginInterface` plugin stack.
      * - Retrieves wishlist item by data provided in the `WishlistItemTransfer` from Persistence.
      * - Updates existing wishlist item in database.
      * - Returns `isSuccess=true` with updated wishlist item on success or `isSuccess=false` with error messages otherwise.

--- a/src/Spryker/Zed/Wishlist/Business/WishlistFacadeInterface.php
+++ b/src/Spryker/Zed/Wishlist/Business/WishlistFacadeInterface.php
@@ -10,6 +10,7 @@ namespace Spryker\Zed\Wishlist\Business;
 use Generated\Shared\Transfer\CustomerTransfer;
 use Generated\Shared\Transfer\WishlistFilterTransfer;
 use Generated\Shared\Transfer\WishlistItemCollectionTransfer;
+use Generated\Shared\Transfer\WishlistItemResponseTransfer;
 use Generated\Shared\Transfer\WishlistItemTransfer;
 use Generated\Shared\Transfer\WishlistOverviewRequestTransfer;
 use Generated\Shared\Transfer\WishlistResponseTransfer;
@@ -235,4 +236,19 @@ interface WishlistFacadeInterface
      * @return \Generated\Shared\Transfer\WishlistResponseTransfer
      */
     public function getWishlistByFilter(WishlistFilterTransfer $wishlistFilterTransfer): WishlistResponseTransfer;
+
+    /**
+     * Specification:
+     * - Expects `WishlistItemTransfer.idWishlistItem` or `WishlistItemTransfer.uuid` to be set.
+     * - Retrieves wishlist item by data provided in the `WishlistItemTransfer` from Persistence.
+     * - Updates existing wishlist item in database.
+     * - Returns `isSuccess=true` with updated wishlist item on success or `isSuccess=false` with error messages otherwise.
+     *
+     * @api
+     *
+     * @param \Generated\Shared\Transfer\WishlistItemTransfer $wishlistItemTransfer
+     *
+     * @return \Generated\Shared\Transfer\WishlistItemResponseTransfer
+     */
+    public function updateWishlistItem(WishlistItemTransfer $wishlistItemTransfer): WishlistItemResponseTransfer;
 }

--- a/src/Spryker/Zed/Wishlist/Business/Writer/WishlistItemWriter.php
+++ b/src/Spryker/Zed/Wishlist/Business/Writer/WishlistItemWriter.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\Wishlist\Business\Writer;
+
+use Generated\Shared\Transfer\MessageTransfer;
+use Generated\Shared\Transfer\WishlistItemCriteriaTransfer;
+use Generated\Shared\Transfer\WishlistItemResponseTransfer;
+use Generated\Shared\Transfer\WishlistItemTransfer;
+use Spryker\Zed\Wishlist\Persistence\WishlistEntityManagerInterface;
+use Spryker\Zed\Wishlist\Persistence\WishlistRepositoryInterface;
+
+class WishlistItemWriter implements WishlistItemWriterInterface
+{
+    /**
+     * @var string
+     */
+    protected const GLOSSARY_KEY_WISHLIST_ITEM_NOT_FOUND = 'wishlist.validation.error.wishlist_item_not_found';
+
+    /**
+     * @var string
+     */
+    protected const GLOSSARY_KEY_WISHLIST_ITEM_CANNOT_BE_UPDATED = 'wishlist.validation.error.wishlist_item_cannot_be_updated';
+
+    /**
+     * @var \Spryker\Zed\Wishlist\Persistence\WishlistEntityManagerInterface
+     */
+    protected $wishlistEntityManager;
+
+    /**
+     * @var \Spryker\Zed\Wishlist\Persistence\WishlistRepositoryInterface
+     */
+    protected $wishlistRepository;
+
+    /**
+     * @param \Spryker\Zed\Wishlist\Persistence\WishlistEntityManagerInterface $wishlistEntityManager
+     * @param \Spryker\Zed\Wishlist\Persistence\WishlistRepositoryInterface $wishlistRepository
+     */
+    public function __construct(
+        WishlistEntityManagerInterface $wishlistEntityManager,
+        WishlistRepositoryInterface $wishlistRepository
+    ) {
+        $this->wishlistEntityManager = $wishlistEntityManager;
+        $this->wishlistRepository = $wishlistRepository;
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\WishlistItemTransfer $wishlistItemTransfer
+     *
+     * @return \Generated\Shared\Transfer\WishlistItemResponseTransfer
+     */
+    public function updateWishlistItem(WishlistItemTransfer $wishlistItemTransfer): WishlistItemResponseTransfer
+    {
+        if (!$wishlistItemTransfer->getIdWishlistItem()) {
+            return $this->getErrorResponse(static::GLOSSARY_KEY_WISHLIST_ITEM_CANNOT_BE_UPDATED);
+        }
+
+        $persistedWishlistItem = $this->wishlistRepository
+            ->findWishlistItem($this->createWishlistItemCriteria($wishlistItemTransfer));
+
+        if (!$persistedWishlistItem) {
+            return $this->getErrorResponse(static::GLOSSARY_KEY_WISHLIST_ITEM_NOT_FOUND);
+        }
+
+        $persistedWishlistItem->fromArray($wishlistItemTransfer->modifiedToArray());
+        $wishlistItemTransfer = $this->wishlistEntityManager->updateWishlistItem($persistedWishlistItem);
+
+        return (new WishlistItemResponseTransfer())
+            ->setIsSuccess(true)
+            ->setWishlistItem($wishlistItemTransfer);
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\WishlistItemTransfer $wishlistItemTransfer
+     *
+     * @return \Generated\Shared\Transfer\WishlistItemCriteriaTransfer
+     */
+    protected function createWishlistItemCriteria(WishlistItemTransfer $wishlistItemTransfer): WishlistItemCriteriaTransfer
+    {
+        return (new WishlistItemCriteriaTransfer())
+            ->setIdWishlistItem($wishlistItemTransfer->getIdWishlistItem());
+    }
+
+    /**
+     * @param string $message
+     *
+     * @return \Generated\Shared\Transfer\WishlistItemResponseTransfer
+     */
+    protected function getErrorResponse(string $message): WishlistItemResponseTransfer
+    {
+        $messageTransfer = (new MessageTransfer())
+            ->setValue($message);
+
+        return (new WishlistItemResponseTransfer())
+            ->setIsSuccess(false)
+            ->addMessage($messageTransfer);
+    }
+}

--- a/src/Spryker/Zed/Wishlist/Business/Writer/WishlistItemWriterInterface.php
+++ b/src/Spryker/Zed/Wishlist/Business/Writer/WishlistItemWriterInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\Wishlist\Business\Writer;
+
+use Generated\Shared\Transfer\WishlistItemResponseTransfer;
+use Generated\Shared\Transfer\WishlistItemTransfer;
+
+interface WishlistItemWriterInterface
+{
+    /**
+     * @param \Generated\Shared\Transfer\WishlistItemTransfer $wishlistItemTransfer
+     *
+     * @return \Generated\Shared\Transfer\WishlistItemResponseTransfer
+     */
+    public function updateWishlistItem(WishlistItemTransfer $wishlistItemTransfer): WishlistItemResponseTransfer;
+}

--- a/src/Spryker/Zed/Wishlist/Communication/Controller/GatewayController.php
+++ b/src/Spryker/Zed/Wishlist/Communication/Controller/GatewayController.php
@@ -10,6 +10,7 @@ namespace Spryker\Zed\Wishlist\Communication\Controller;
 use Generated\Shared\Transfer\CustomerTransfer;
 use Generated\Shared\Transfer\WishlistFilterTransfer;
 use Generated\Shared\Transfer\WishlistItemCollectionTransfer;
+use Generated\Shared\Transfer\WishlistItemResponseTransfer;
 use Generated\Shared\Transfer\WishlistItemTransfer;
 use Generated\Shared\Transfer\WishlistOverviewRequestTransfer;
 use Generated\Shared\Transfer\WishlistResponseTransfer;
@@ -149,5 +150,15 @@ class GatewayController extends AbstractGatewayController
     public function getWishlistByFilterAction(WishlistFilterTransfer $wishlistFilterTransfer): WishlistResponseTransfer
     {
         return $this->getFacade()->getWishlistByFilter($wishlistFilterTransfer);
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\WishlistItemTransfer $wishlistItemTransfer
+     *
+     * @return \Generated\Shared\Transfer\WishlistItemResponseTransfer
+     */
+    public function updateWishlistItemAction(WishlistItemTransfer $wishlistItemTransfer): WishlistItemResponseTransfer
+    {
+        return $this->getFacade()->updateWishlistItem($wishlistItemTransfer);
     }
 }

--- a/src/Spryker/Zed/Wishlist/Persistence/Mapper/WishlistMapper.php
+++ b/src/Spryker/Zed/Wishlist/Persistence/Mapper/WishlistMapper.php
@@ -66,6 +66,23 @@ class WishlistMapper implements WishlistMapperInterface
         SpyWishlistItem $wishlistItemEntity,
         WishlistItemTransfer $wishlistItemTransfer
     ): WishlistItemTransfer {
-        return $wishlistItemTransfer->fromArray($wishlistItemEntity->toArray(), true);
+        return $wishlistItemTransfer
+            ->fromArray($wishlistItemEntity->toArray(), true)
+            ->setWishlistName($wishlistItemEntity->getSpyWishlist()->getName());
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\WishlistItemTransfer $wishlistItemTransfer
+     * @param \Orm\Zed\Wishlist\Persistence\SpyWishlistItem $wishlistItemEntity
+     *
+     * @return \Orm\Zed\Wishlist\Persistence\SpyWishlistItem
+     */
+    public function mapWishlistItemTransferToWishlistItemEntity(
+        WishlistItemTransfer $wishlistItemTransfer,
+        SpyWishlistItem $wishlistItemEntity
+    ): SpyWishlistItem {
+        $wishlistItemEntity->fromArray($wishlistItemTransfer->toArray());
+
+        return $wishlistItemEntity;
     }
 }

--- a/src/Spryker/Zed/Wishlist/Persistence/Mapper/WishlistMapperInterface.php
+++ b/src/Spryker/Zed/Wishlist/Persistence/Mapper/WishlistMapperInterface.php
@@ -48,4 +48,15 @@ interface WishlistMapperInterface
         SpyWishlistItem $wishlistItemEntity,
         WishlistItemTransfer $wishlistItemTransfer
     ): WishlistItemTransfer;
+
+    /**
+     * @param \Generated\Shared\Transfer\WishlistItemTransfer $wishlistItemTransfer
+     * @param \Orm\Zed\Wishlist\Persistence\SpyWishlistItem $wishlistItemEntity
+     *
+     * @return \Orm\Zed\Wishlist\Persistence\SpyWishlistItem
+     */
+    public function mapWishlistItemTransferToWishlistItemEntity(
+        WishlistItemTransfer $wishlistItemTransfer,
+        SpyWishlistItem $wishlistItemEntity
+    ): SpyWishlistItem;
 }

--- a/src/Spryker/Zed/Wishlist/Persistence/WishlistEntityManager.php
+++ b/src/Spryker/Zed/Wishlist/Persistence/WishlistEntityManager.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\Wishlist\Persistence;
+
+use Generated\Shared\Transfer\WishlistItemTransfer;
+use Spryker\Zed\Kernel\Persistence\AbstractEntityManager;
+
+/**
+ * @method \Spryker\Zed\Wishlist\Persistence\WishlistPersistenceFactory getFactory()
+ */
+class WishlistEntityManager extends AbstractEntityManager implements WishlistEntityManagerInterface
+{
+    /**
+     * @param \Generated\Shared\Transfer\WishlistItemTransfer $wishlistItemTransfer
+     *
+     * @return \Generated\Shared\Transfer\WishlistItemTransfer
+     */
+    public function updateWishlistItem(WishlistItemTransfer $wishlistItemTransfer): WishlistItemTransfer
+    {
+        $wishlistItemEntity = $this->getFactory()
+            ->createWishlistItemQuery()
+            ->filterByIdWishlistItem($wishlistItemTransfer->getIdWishlistItemOrFail())
+            ->findOne();
+
+        $wishlistItemEntity = $this->getFactory()
+            ->createWishlistMapper()
+            ->mapWishlistItemTransferToWishlistItemEntity($wishlistItemTransfer, $wishlistItemEntity);
+
+        $wishlistItemEntity->save();
+
+        return $wishlistItemTransfer;
+    }
+}

--- a/src/Spryker/Zed/Wishlist/Persistence/WishlistEntityManagerInterface.php
+++ b/src/Spryker/Zed/Wishlist/Persistence/WishlistEntityManagerInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\Wishlist\Persistence;
+
+use Generated\Shared\Transfer\WishlistItemTransfer;
+
+interface WishlistEntityManagerInterface
+{
+    /**
+     * @param \Generated\Shared\Transfer\WishlistItemTransfer $wishlistItemTransfer
+     *
+     * @return \Generated\Shared\Transfer\WishlistItemTransfer
+     */
+    public function updateWishlistItem(WishlistItemTransfer $wishlistItemTransfer): WishlistItemTransfer;
+}

--- a/src/Spryker/Zed/Wishlist/Persistence/WishlistRepositoryInterface.php
+++ b/src/Spryker/Zed/Wishlist/Persistence/WishlistRepositoryInterface.php
@@ -9,6 +9,8 @@ namespace Spryker\Zed\Wishlist\Persistence;
 
 use Generated\Shared\Transfer\WishlistCollectionTransfer;
 use Generated\Shared\Transfer\WishlistFilterTransfer;
+use Generated\Shared\Transfer\WishlistItemCriteriaTransfer;
+use Generated\Shared\Transfer\WishlistItemTransfer;
 use Generated\Shared\Transfer\WishlistTransfer;
 
 interface WishlistRepositoryInterface
@@ -26,4 +28,11 @@ interface WishlistRepositoryInterface
      * @return \Generated\Shared\Transfer\WishlistTransfer|null
      */
     public function findWishlistByFilter(WishlistFilterTransfer $wishlistFilterTransfer): ?WishlistTransfer;
+
+    /**
+     * @param \Generated\Shared\Transfer\WishlistItemCriteriaTransfer $wishlistItemCriteriaTransfer
+     *
+     * @return \Generated\Shared\Transfer\WishlistItemTransfer|null
+     */
+    public function findWishlistItem(WishlistItemCriteriaTransfer $wishlistItemCriteriaTransfer): ?WishlistItemTransfer;
 }

--- a/src/Spryker/Zed/Wishlist/WishlistDependencyProvider.php
+++ b/src/Spryker/Zed/Wishlist/WishlistDependencyProvider.php
@@ -23,6 +23,16 @@ class WishlistDependencyProvider extends AbstractBundleDependencyProvider
     public const PLUGINS_ADD_ITEM_PRE_CHECK = 'PLUGINS_ADD_ITEM_PRE_CHECK';
 
     /**
+     * @var string
+     */
+    public const PLUGINS_UPDATE_ITEM_PRE_CHECK = 'PLUGINS_UPDATE_ITEM_PRE_CHECK';
+
+    /**
+     * @var string
+     */
+    public const PLUGINS_WISHLIST_PRE_UPDATE_ITEM = 'PLUGINS_WISHLIST_PRE_UPDATE_ITEM';
+
+    /**
      * @param \Spryker\Zed\Kernel\Container $container
      *
      * @return \Spryker\Zed\Kernel\Container
@@ -42,6 +52,8 @@ class WishlistDependencyProvider extends AbstractBundleDependencyProvider
         };
 
         $container = $this->addAddItemPreCheckPlugins($container);
+        $container = $this->addUpdateItemPreCheckPlugins($container);
+        $container = $this->addWishlistPreUpdateItemPlugins($container);
 
         return $container;
     }
@@ -72,6 +84,50 @@ class WishlistDependencyProvider extends AbstractBundleDependencyProvider
      * @return \Spryker\Zed\WishlistExtension\Dependency\Plugin\AddItemPreCheckPluginInterface[]
      */
     protected function getAddItemPreCheckPlugins(): array
+    {
+        return [];
+    }
+
+    /**
+     * @param \Spryker\Zed\Kernel\Container $container
+     *
+     * @return \Spryker\Zed\Kernel\Container
+     */
+    protected function addUpdateItemPreCheckPlugins(Container $container): Container
+    {
+        $container->set(static::PLUGINS_UPDATE_ITEM_PRE_CHECK, function () {
+            return $this->getUpdateItemPreCheckPlugins();
+        });
+
+        return $container;
+    }
+
+    /**
+     * @param \Spryker\Zed\Kernel\Container $container
+     *
+     * @return \Spryker\Zed\Kernel\Container
+     */
+    protected function addWishlistPreUpdateItemPlugins(Container $container): Container
+    {
+        $container->set(static::PLUGINS_WISHLIST_PRE_UPDATE_ITEM, function () {
+            return $this->getWishlistPreUpdateItemPlugins();
+        });
+
+        return $container;
+    }
+
+    /**
+     * @return array<\Spryker\Zed\WishlistExtension\Dependency\Plugin\WishlistPreUpdateItemPluginInterface>
+     */
+    protected function getWishlistPreUpdateItemPlugins(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return array<\Spryker\Zed\WishlistExtension\Dependency\Plugin\UpdateItemPreCheckPluginInterface>
+     */
+    protected function getUpdateItemPreCheckPlugins(): array
     {
         return [];
     }

--- a/tests/SprykerTest/Zed/Wishlist/Business/UpdateWishlistItemFacadeTest.php
+++ b/tests/SprykerTest/Zed/Wishlist/Business/UpdateWishlistItemFacadeTest.php
@@ -1,0 +1,193 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace SprykerTest\Zed\Wishlist\Business;
+
+use Codeception\TestCase\Test;
+use Generated\Shared\Transfer\WishlistItemTransfer;
+use Generated\Shared\Transfer\WishlistTransfer;
+
+/**
+ * Auto-generated group annotations
+ *
+ * @group SprykerTest
+ * @group Zed
+ * @group Wishlist
+ * @group Business
+ * @group Facade
+ * @group UpdateWishlistItemFacadeTest
+ * Add your own group annotations below this line
+ */
+class UpdateWishlistItemFacadeTest extends Test
+{
+    /**
+     * @var string
+     */
+    protected const FAKE_PRODUCT_CONFIGURATION = 'FAKE_PRODUCT_CONFIGURATION';
+
+    /**
+     * @var int
+     */
+    protected const FAKE_ID_WISHLIST_ITEN = 88888;
+
+    /**
+     * @see \Spryker\Zed\Wishlist\Business\Writer\WishlistItemWriter::GLOSSARY_KEY_WISHLIST_ITEM_NOT_FOUND
+     *
+     * @var string
+     */
+    protected const GLOSSARY_KEY_WISHLIST_ITEM_NOT_FOUND = 'wishlist.validation.error.wishlist_item_not_found';
+
+    /**
+     * @see \Spryker\Zed\Wishlist\Business\Writer\WishlistItemWriter::GLOSSARY_KEY_WISHLIST_ITEM_CANNOT_BE_UPDATED
+     *
+     * @var string
+     */
+    protected const GLOSSARY_KEY_WISHLIST_ITEM_CANNOT_BE_UPDATED = 'wishlist.validation.error.wishlist_item_cannot_be_updated';
+
+    /**
+     * @var \SprykerTest\Zed\Wishlist\WishlistBusinessTester
+     */
+    protected $tester;
+
+    /**
+     * @var \Generated\Shared\Transfer\CustomerTransfer
+     */
+    protected $customerTransfer;
+
+    /**
+     * @var \Generated\Shared\Transfer\WishlistTransfer
+     */
+    protected $wishlistTransfer;
+
+    /**
+     * @var \Generated\Shared\Transfer\ProductConcreteTransfer
+     */
+    protected $productConcreteTransfer;
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->customerTransfer = $this->tester->haveCustomer();
+        $this->productConcreteTransfer = $this->tester->haveProduct();
+
+        $this->wishlistTransfer = $this->tester->haveWishlist([
+            WishlistTransfer::FK_CUSTOMER => $this->customerTransfer->getIdCustomer(),
+        ]);
+    }
+
+    /**
+     * @return void
+     */
+    public function testUpdateWishlistItemEnsureThatWishlistItemPropertyCanBeUpdated(): void
+    {
+        // Arrange
+        $wishlistItemTransfer = $this->createDefaultWishlistItem();
+
+        $wishlistItemTransfer = (new WishlistItemTransfer())
+            ->setIdWishlistItem($wishlistItemTransfer->getIdWishlistItem())
+            ->setProductConfigurationInstanceData(static::FAKE_PRODUCT_CONFIGURATION);
+
+        // Act
+        $wishlistItemResponseTransfer = $this->tester
+            ->getFacade()
+            ->updateWishlistItem($wishlistItemTransfer);
+
+        // Assert
+        $this->assertTrue($wishlistItemResponseTransfer->getIsSuccess());
+        $this->assertSame(
+            static::FAKE_PRODUCT_CONFIGURATION,
+            $this->tester->getWishlistItemFromPersistence($wishlistItemTransfer->getIdWishlistItem())->getProductConfigurationInstanceData(),
+            'Wishlist item property was not updated in database storage.'
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testUpdateWishlistItemByUuidEnsureThatWishlistItemPropertyWasUpdated(): void
+    {
+        // Arrange
+        $wishlistItemTransfer = $this->createDefaultWishlistItem();
+
+        $wishlistItemTransfer = (new WishlistItemTransfer())
+            ->setIdWishlistItem($wishlistItemTransfer->getIdWishlistItem())
+            ->setProductConfigurationInstanceData(static::FAKE_PRODUCT_CONFIGURATION);
+
+        // Act
+        $wishlistItemResponseTransfer = $this->tester
+            ->getFacade()
+            ->updateWishlistItem($wishlistItemTransfer);
+
+        // Assert
+        $this->assertSame(
+            static::FAKE_PRODUCT_CONFIGURATION,
+            $wishlistItemResponseTransfer->getWishlistItemOrFail()->getProductConfigurationInstanceData(),
+            'Wishlist item property was not updated in result transfer.'
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testUpdateWishlistItemWithFakeWishlistItemId(): void
+    {
+        // Arrange
+        $wishlistItemTransfer = (new WishlistItemTransfer())
+            ->setIdWishlistItem(static::FAKE_ID_WISHLIST_ITEN);
+
+        // Act
+        $wishlistItemResponseTransfer = $this->tester
+            ->getFacade()
+            ->updateWishlistItem($wishlistItemTransfer);
+
+        // Assert
+        $this->assertFalse($wishlistItemResponseTransfer->getIsSuccess());
+        $this->assertSame(
+            static::GLOSSARY_KEY_WISHLIST_ITEM_NOT_FOUND,
+            $wishlistItemResponseTransfer->getMessages()->offsetGet(0)->getValue()
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testUpdateWishlistItemWithoutExpectedProperties(): void
+    {
+        // Arrange
+        $wishlistItemTransfer = (new WishlistItemTransfer())
+            ->setIdWishlistItem(null);
+
+        // Act
+        $wishlistItemResponseTransfer = $this->tester
+            ->getFacade()
+            ->updateWishlistItem($wishlistItemTransfer);
+
+        // Assert
+        $this->assertFalse($wishlistItemResponseTransfer->getIsSuccess());
+        $this->assertSame(
+            static::GLOSSARY_KEY_WISHLIST_ITEM_CANNOT_BE_UPDATED,
+            $wishlistItemResponseTransfer->getMessages()->offsetGet(0)->getValue()
+        );
+    }
+
+    /**
+     * @return \Generated\Shared\Transfer\WishlistItemTransfer
+     */
+    protected function createDefaultWishlistItem(): WishlistItemTransfer
+    {
+        return $this->tester->haveItemInWishlist([
+            WishlistItemTransfer::FK_WISHLIST => $this->wishlistTransfer->getIdWishlist(),
+            WishlistItemTransfer::SKU => $this->productConcreteTransfer->getSku(),
+            WishlistItemTransfer::FK_CUSTOMER => $this->customerTransfer->getIdCustomer(),
+            WishlistItemTransfer::PRODUCT_CONFIGURATION_INSTANCE_DATA => '',
+        ]);
+    }
+}

--- a/tests/SprykerTest/Zed/Wishlist/Business/UpdateWishlistItemFacadeTest.php
+++ b/tests/SprykerTest/Zed/Wishlist/Business/UpdateWishlistItemFacadeTest.php
@@ -10,10 +10,11 @@ namespace SprykerTest\Zed\Wishlist\Business;
 use Codeception\TestCase\Test;
 use Generated\Shared\Transfer\ProductConcreteTransfer;
 use Generated\Shared\Transfer\WishlistItemTransfer;
-use Generated\Shared\Transfer\WishlistPreAddItemCheckResponseTransfer;
+use Generated\Shared\Transfer\WishlistPreUpdateItemCheckResponseTransfer;
 use Generated\Shared\Transfer\WishlistTransfer;
 use Spryker\Zed\Wishlist\WishlistDependencyProvider;
-use Spryker\Zed\WishlistExtension\Dependency\Plugin\AddItemPreCheckPluginInterface;
+use Spryker\Zed\WishlistExtension\Dependency\Plugin\UpdateItemPreCheckPluginInterface;
+use Spryker\Zed\WishlistExtension\Dependency\Plugin\WishlistPreUpdateItemPluginInterface;
 
 /**
  * Auto-generated group annotations
@@ -213,7 +214,7 @@ class UpdateWishlistItemFacadeTest extends Test
     /**
      * @return void
      */
-    public function testUpdateWishlistItemEnsureThatAddItemPreCheckPluginStackExecuted(): void
+    public function testUpdateWishlistItemEnsureThatUpdateItemPreCheckPluginStackExecuted(): void
     {
         // Arrange
         $wishlistItemTransfer = $this->createDefaultWishlistItem();
@@ -224,8 +225,8 @@ class UpdateWishlistItemFacadeTest extends Test
             ->setSku($newProductConcrete->getSku());
 
         // Assert
-        $this->tester->setDependency(WishlistDependencyProvider::PLUGINS_ADD_ITEM_PRE_CHECK, [
-            $this->getAddItemPreCheckPluginMock(),
+        $this->tester->setDependency(WishlistDependencyProvider::PLUGINS_UPDATE_ITEM_PRE_CHECK, [
+            $this->getUpdateItemPreCheckPluginMock(),
         ]);
 
         // Act
@@ -233,20 +234,61 @@ class UpdateWishlistItemFacadeTest extends Test
     }
 
     /**
-     * @return \PHPUnit\Framework\MockObject\MockObject|\Spryker\Zed\WishlistExtension\Dependency\Plugin\AddItemPreCheckPluginInterface
+     * @return void
      */
-    protected function getAddItemPreCheckPluginMock(): AddItemPreCheckPluginInterface
+    public function testUpdateWishlistItemEnsureThatWishlistPreUpdateItemPluginStackExecuted(): void
     {
-        $addItemPreCheckPluginMock = $this
-            ->getMockBuilder(AddItemPreCheckPluginInterface::class)
+        // Arrange
+        $wishlistItemTransfer = $this->createDefaultWishlistItem();
+        $newProductConcrete = $this->tester->haveProduct();
+
+        $wishlistItemTransfer = (new WishlistItemTransfer())
+            ->setIdWishlistItem($wishlistItemTransfer->getIdWishlistItem())
+            ->setSku($newProductConcrete->getSku());
+
+        // Assert
+        $this->tester->setDependency(WishlistDependencyProvider::PLUGINS_WISHLIST_PRE_UPDATE_ITEM, [
+            $this->getWishlistPreUpdateItemPluginMock(),
+        ]);
+
+        // Act
+        $this->tester->getFacade()->updateWishlistItem($wishlistItemTransfer);
+    }
+
+    /**
+     * @return \PHPUnit\Framework\MockObject\MockObject|\Spryker\Zed\WishlistExtension\Dependency\Plugin\UpdateItemPreCheckPluginInterface
+     */
+    protected function getUpdateItemPreCheckPluginMock(): UpdateItemPreCheckPluginInterface
+    {
+        $updateItemPreCheckPluginMock = $this
+            ->getMockBuilder(UpdateItemPreCheckPluginInterface::class)
             ->getMock();
 
-        $addItemPreCheckPluginMock
+        $updateItemPreCheckPluginMock
             ->expects($this->once())
             ->method('check')
-            ->willReturn((new WishlistPreAddItemCheckResponseTransfer())->setIsSuccess(true));
+            ->willReturn((new WishlistPreUpdateItemCheckResponseTransfer())->setIsSuccess(true));
 
-        return $addItemPreCheckPluginMock;
+        return $updateItemPreCheckPluginMock;
+    }
+
+    /**
+     * @return \PHPUnit\Framework\MockObject\MockObject|\Spryker\Zed\WishlistExtension\Dependency\Plugin\WishlistPreUpdateItemPluginInterface
+     */
+    protected function getWishlistPreUpdateItemPluginMock(): WishlistPreUpdateItemPluginInterface
+    {
+        $wishlistPreUpdateItemPluginMock = $this
+            ->getMockBuilder(WishlistPreUpdateItemPluginInterface::class)
+            ->getMock();
+
+        $wishlistPreUpdateItemPluginMock
+            ->expects($this->once())
+            ->method('preUpdateItem')
+            ->willReturnCallback(function (WishlistItemTransfer $wishlistItemTransfer) {
+                return $wishlistItemTransfer;
+            });
+
+        return $wishlistPreUpdateItemPluginMock;
     }
 
     /**

--- a/tests/SprykerTest/Zed/Wishlist/_support/WishlistBusinessTester.php
+++ b/tests/SprykerTest/Zed/Wishlist/_support/WishlistBusinessTester.php
@@ -8,6 +8,8 @@
 namespace SprykerTest\Zed\Wishlist;
 
 use Codeception\Actor;
+use Generated\Shared\Transfer\WishlistItemCriteriaTransfer;
+use Generated\Shared\Transfer\WishlistItemTransfer;
 
 /**
  * Inherited Methods
@@ -22,6 +24,7 @@ use Codeception\Actor;
  * @method void lookForwardTo($achieveValue)
  * @method void comment($description)
  * @method \Codeception\Lib\Friend haveFriend($name, $actorClass = NULL)
+ * @method \Spryker\Zed\Wishlist\Business\WishlistFacadeInterface getFacade()
  *
  * @SuppressWarnings(PHPMD)
  */
@@ -29,7 +32,18 @@ class WishlistBusinessTester extends Actor
 {
     use _generated\WishlistBusinessTesterActions;
 
-   /**
-    * Define custom actions here
-    */
+    /**
+     * @param int $idWishlistItem
+     *
+     * @return \Generated\Shared\Transfer\WishlistItemTransfer
+     */
+    public function getWishlistItemFromPersistence(int $idWishlistItem): WishlistItemTransfer
+    {
+        $wishlistItemCriteriaTransfer = (new WishlistItemCriteriaTransfer())
+            ->setIdWishlistItem($idWishlistItem);
+
+        return $this->getFacade()
+            ->getWishlistItem($wishlistItemCriteriaTransfer)
+            ->getWishlistItemOrFail();
+    }
 }


### PR DESCRIPTION
Branch: backport/6.6.0
Ticket: https://spryker.atlassian.net/browse/CC-12637
Target version: 6.6.0
RG: https://release.spryker.com/release-groups/view/3827

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Wishlist               | minor                 |                       |

#### Release Notes

{skip}

-----------------------------------------

#### Module Wishlist

##### Change log

Improvements

- Introduced `WishlistClientInterface::updateWishlistItem()`.
- Introduced `WishlistFacadeInterface::updateWishlistItem()` in order to update existing wishlist item.
- Introduced `Message.value` transfer property.
- Introduced `WishlistItemResponse` transfer.
- Introduced `WishlistPreUpdateItemCheckResponse` transfer.
